### PR TITLE
Card spotlight hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,14 +654,14 @@ function Card3D(card, ev) {
     let mouseY = ev.offsetY;
     let rotateY = map(mouseX, 0, 180, -25, 25);
     let rotateX = map(mouseY, 0, 250, 25, -25);
-    let brightness = map(mouseY, 0, 250, 1.5, 0.5);
+    //let brightness = map(mouseY, 0, 250, 1.5, 0.5);
 
+    // Spotlight card effects inspired by Scrydex    
     let spotlight = card.querySelector('img.spotlight');
-    
     spotlight.style.display = `block`;
     spotlight.style.mask = `radial-gradient(circle at ${mouseX}px ${mouseY}px, rgba(255, 255, 255, 0.35), transparent 75%)`;
+    spotlight.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg) scaleX(0.875) scaleY(0.85)`;
 
-    spotlight.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
     img.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
     //img.style.filter = `brightness(${brightness})`;
 }


### PR DESCRIPTION
Added a hover effect that was inspired by Scrydex. See sample: https://scrydex.com/pokemon/expansions/phantasmal-flames/me2

<img width="658" height="490" alt="image" src="https://github.com/user-attachments/assets/5f0fda0e-382a-4ab0-af77-124ba0e97044" />

The light is subtle on image but noticeable during usage. This is great so that the card is visible enough while presenting the effect.

For now I turned off the previous *brightness* effect that adjust on mouse y value. It can be turned on together with this effect but I'll leave it as it is right now.

There's a slight problem where the size is off and goes beyond the actual card size. This was caused by using another copy of the same image and just masking it, then scaling its size. It's a minor issue and could be fixed with a better approach next time.

<img width="509" height="453" alt="image" src="https://github.com/user-attachments/assets/4609cbdb-d14f-4fff-ae6e-6358fdf1274c" />
